### PR TITLE
fix: only apply CorrectPlayerMovePrediction rotation when prediction_type is 'vehicle'

### DIFF
--- a/docs/in-dev/bedrock-first-physics-implementation-notes.md
+++ b/docs/in-dev/bedrock-first-physics-implementation-notes.md
@@ -51,6 +51,7 @@ This note records the local source pass used for the Bedrock physics implementat
 - This is a Bedrock-first player movement implementation, not a full Bedrock client clone.
 - It currently relies on prismarine block collision `shapes`. Special block-specific behaviors are only covered where the local block data exposes enough information or where the behavior is generic, such as friction and climbable-name detection.
 - Geyser/Boar both treat server corrections as authoritative. The plugin keeps that model: `move_player`, `respawn`, `correct_player_move_prediction`, and velocity hint packets reset or update local movement state.
+- `CorrectPlayerMovePredictionPacket.Rotation` is conditional on `PredictionType == Vehicle` per Mojang's schema (`bedrock-protocol-docs/json/CorrectPlayerMovePredictionPacket.json`: "Corrected rotation. Only sent when PredictionType is Vehicle"). The `1.26.10` `proto.yml` schema does not gate the field, so the parser zero-fills `rotation` for `player` predictions. Both `src/builtins/physics/index.js` and `src/builtins/entities.js` only write `pitch`, `yaw`, and `headYaw` when `prediction_type === 'vehicle'`; writing them unconditionally snaps the bot's yaw to 0 on every server correction. See `test/static/bedrock-rotation.test.js` for the regression coverage.
 - `player_auth_input.delta` is generated from the simulated velocity after collision/drag. Boar explicitly corrects this field server-side because it is validation-sensitive.
 
 ## Follow-up candidates

--- a/src/builtins/entities.js
+++ b/src/builtins/entities.js
@@ -225,9 +225,11 @@ module.exports = (botState, options) => {
   botState.client.on('correct_player_move_prediction', (packet) => {
     if (!botState.self) return;
     botState.self.position.set(packet.position.x, packet.position.y, packet.position.z);
-    botState.self.pitch = packet.rotation.x;
-    botState.self.yaw = packet.rotation.z;
-    botState.self.headYaw = packet.rotation.z;
+    if (packet.prediction_type === 'vehicle') {
+      botState.self.pitch = packet.rotation.x;
+      botState.self.yaw = packet.rotation.z;
+      botState.self.headYaw = packet.rotation.z;
+    }
     botState.self.onGround = packet.on_ground;
     // delta and tick are available but not stored by default
   });

--- a/src/builtins/physics/index.js
+++ b/src/builtins/physics/index.js
@@ -325,9 +325,11 @@ module.exports = function bedrockPhysicsPlugin(botState, options = {}) {
       pkt.position.z
     );
 
-    botState.self.pitch = rotationPitch(pkt.rotation);
-    botState.self.yaw = rotationYaw(pkt.rotation);
-    botState.self.headYaw = botState.self.yaw;
+    if (pkt.prediction_type === 'vehicle') {
+      botState.self.pitch = rotationPitch(pkt.rotation);
+      botState.self.yaw = rotationYaw(pkt.rotation);
+      botState.self.headYaw = botState.self.yaw;
+    }
     botState.self.onGround = !!pkt.on_ground;
     botState.self.velocity.set(0, 0, 0);
     botState.self.unvalidatedPosition = botState.self.position.clone();

--- a/test/static/bedrock-rotation.test.js
+++ b/test/static/bedrock-rotation.test.js
@@ -47,7 +47,7 @@ describe('Bedrock rotation mapping', function () {
     assert.strictEqual(botState.self.headYaw, 34)
   })
 
-  it('uses vec2f.z as yaw when entities handles movement correction', function () {
+  it('uses vec2f.z as yaw when entities handles movement correction and prediction_type is "vehicle"', function () {
     const client = createClient()
     const botState = new EventEmitter()
     botState.client = client
@@ -57,17 +57,118 @@ describe('Bedrock rotation mapping', function () {
     botState.entities = new Map()
     botState.players = new Map()
     botState.self = new TestEntity(1n)
+    botState.self.pitch = 10;
+    botState.self.yaw = 20;
+    botState.self.headYaw = 30 
 
     installEntities(botState, {})
 
     client.emit('correct_player_move_prediction', {
       position: { x: 1, y: 65, z: 2 },
       rotation: { x: 15, z: 75 },
-      on_ground: true
+      on_ground: true,
+      prediction_type: 'vehicle'
     })
 
     assert.strictEqual(botState.self.pitch, 15)
     assert.strictEqual(botState.self.yaw, 75)
     assert.strictEqual(botState.self.headYaw, 75)
+  })
+
+  it('preserves rotation when entities handles movement correction and prediction_type is "player"', function () {
+    const client = createClient()
+    const botState = new EventEmitter()
+    botState.client = client
+    botState.registry = { entitiesArray: [] }
+    botState.entityClass = TestEntity
+    botState.itemClass = { fromNotch: () => null }
+    botState.entities = new Map()
+    botState.players = new Map()
+    botState.self = new TestEntity(1n)
+    botState.self.pitch = 10;
+    botState.self.yaw = 20;
+    botState.self.headYaw = 30
+
+    installEntities(botState, {})
+
+    // Rotation is zero-filled by the parser for "player" predictions
+    // (only sent on the wire when prediction_type is "vehicle"); writing
+    // it would snap the bot's yaw/pitch to 0.
+    client.emit('correct_player_move_prediction', {
+      position: { x: 1, y: 65, z: 2 },
+      rotation: { x: 0, z: 0 },
+      on_ground: true,
+      prediction_type: 'player'
+    })
+
+    assert.strictEqual(botState.self.pitch, 10)
+    assert.strictEqual(botState.self.yaw, 20)
+    assert.strictEqual(botState.self.headYaw, 30)
+  })
+
+  it('uses vec2f.z as yaw when physics handles movement correction and prediction_type is "vehicle"', function () {
+    const client = createClient()
+    const botState = new EventEmitter()
+    botState.client = client
+    botState.version = '1.26.10'
+    botState.worldDecodeEnabled = true
+    botState.physicsEnabled = true
+    botState.self = new TestEntity(1n)
+    botState.self.runtimeId = 1n
+    botState.self.pitch = 10;
+    botState.self.yaw = 20;
+    botState.self.headYaw = 30
+    botState.world = {
+      sync: { getBlock: () => null },
+      waitForChunks: async () => {}
+    }
+
+    installPhysics(botState, { worldDecodeEnabled: true, physicsEnabled: true })
+
+    client.emit('correct_player_move_prediction', {
+      position: { x: 1, y: 65, z: 2 },
+      rotation: { x: 15, z: 75 },
+      on_ground: true,
+      prediction_type: 'vehicle'
+    })
+
+    assert.strictEqual(botState.self.pitch, 15)
+    assert.strictEqual(botState.self.yaw, 75)
+    assert.strictEqual(botState.self.headYaw, 75)
+
+    client.emit('close')
+  })
+
+  it('preserves rotation when physics handles movement correction and prediction_type is "player"', function () {
+    const client = createClient()
+    const botState = new EventEmitter()
+    botState.client = client
+    botState.version = '1.26.10'
+    botState.worldDecodeEnabled = true
+    botState.physicsEnabled = true
+    botState.self = new TestEntity(1n)
+    botState.self.runtimeId = 1n
+    botState.self.pitch = 10;
+    botState.self.yaw = 20;
+    botState.self.headYaw = 30
+    botState.world = {
+      sync: { getBlock: () => null },
+      waitForChunks: async () => {}
+    }
+
+    installPhysics(botState, { worldDecodeEnabled: true, physicsEnabled: true })
+
+    client.emit('correct_player_move_prediction', {
+      position: { x: 1, y: 65, z: 2 },
+      rotation: { x: 0, z: 0 },
+      on_ground: true,
+      prediction_type: 'player'
+    })
+
+    assert.strictEqual(botState.self.pitch, 10)
+    assert.strictEqual(botState.self.yaw, 20)
+    assert.strictEqual(botState.self.headYaw, 30)
+
+    client.emit('close')
   })
 })


### PR DESCRIPTION
CorrectPlayerMovePredictionPacket.Rotation is only sent on the wire when PredictionType is "Vehicle" (per Mojang bedrock-protocol-docs: json/CorrectPlayerMovePredictionPacket.json -- "Corrected rotation. Only sent when PredictionType is Vehicle"). The 1.26.10 proto.yml schema doesn't gate the field, so the parser zero-fills it for "player" predictions and writing it snaps the bot's yaw/pitch to 0 on every server correction.

Gate the writes in both src/builtins/entities.js and src/builtins/physics/index.js on prediction_type === 'vehicle'. Add regression tests covering vehicle (applies rotation) and player (preserves pre-set yaw/pitch/headYaw) for both handlers, and document the conditional in the physics implementation notes.